### PR TITLE
Added NFC permissions in the AndroidManifest.xml…

### DIFF
--- a/MASAccessAPISample/src/main/AndroidManifest.xml
+++ b/MASAccessAPISample/src/main/AndroidManifest.xml
@@ -24,5 +24,7 @@
             </intent-filter>
         </activity>
     </application>
-
+    <uses-permission android:name="android.permission.NFC"/>
+    <uses-permission android:name="android.permission.BLUETOOTH"/>
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"/>
 </manifest>


### PR DESCRIPTION
... so that the masui login dialog does not crash the app on real devices.